### PR TITLE
[fix] Force the default target

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -20,12 +20,11 @@ ifeq ($(BOLOS_SDK),)
 $(error BOLOS_SDK is not set)
 endif
 
-# TODO: Remove this hack
-MAKEFLAGS:= -j 1
-
 MY_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
-all: bin/app.elf
+.PHONY: full_build
+full_build: rust
+	$(MAKE) default
 	@echo "#!/usr/bin/env bash" > $(OUTPUT_INSTALLER)
 	@echo "APPNAME=\"${APPNAME}\"" >> $(OUTPUT_INSTALLER)
 	@echo "APPVERSION=\"${APPVERSION}\"" >> $(OUTPUT_INSTALLER)


### PR DESCRIPTION
@lovesh This change does work, however I'm not exactly sure why.

Included SDK Makefiles already define `all` and `bin/app.elf` targets, and I though there was some kind of override shenanigans there, so I renamed your entry point target and explicitly marked it as the default target. The `rust` target is built before anything else, then the `default` (defined as `bin/app.apdu` in the SDK `Makefile.defines` file) target is invoked.

I'm not sure exactly why your Makefile could not properly build today, as we've already deployed this application before, with at first glance the same constraints.